### PR TITLE
Add daily morning embed feature with scheduler and ZenQuotes integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@
 
 The app should now be running and, if your .env file is complete with correct settings, you should see the app add the new commands to your server.
 > Note: This will only happen the first time running the app.
+
+## Morning embed message
+
+Use `/ochtendbericht` to configure one daily morning embed per Discord server. The command lets a server manager choose the target channel, title, description, optional image URL, and whether the message is enabled.
+
+The bot sends enabled morning embeds once per day at a random time between 07:00 and 09:00. Each message includes the ZenQuotes quote of the day from `https://zenquotes.io/api/today`, using `q` as the quote and `a` as the author. By default this window uses the `Europe/Brussels` time zone. Set `MORNING_EMBED_TIME_ZONE` in `.env` to another IANA time zone, for example `America/New_York`, if your server should use a different morning window.

--- a/src/commands/misc/morningEmbed.ts
+++ b/src/commands/misc/morningEmbed.ts
@@ -1,0 +1,127 @@
+import {
+  ApplicationCommandOptionType,
+  ChannelType,
+  EmbedBuilder,
+  PermissionsBitField,
+} from "discord.js";
+import { AppDataSource } from "../../data-source";
+import { MorningEmbed } from "../../entity";
+
+const isValidImageUrl = (imageUrl: string) => {
+  try {
+    const url = new URL(imageUrl);
+    return ["http:", "https:"].includes(url.protocol);
+  } catch {
+    return false;
+  }
+};
+
+export default {
+  name: "ochtendbericht",
+  description: "Stel het dagelijkse ochtendbericht tussen 7u en 9u in",
+  devOnly: false,
+  testOnly: false,
+  permissionsRequired: [PermissionsBitField.Flags.ManageGuild],
+  botPermissions: [
+    PermissionsBitField.Flags.SendMessages,
+    PermissionsBitField.Flags.EmbedLinks,
+  ],
+  options: [
+    {
+      name: "kanaal",
+      description: "Het kanaal waar het ochtendbericht naartoe moet",
+      type: ApplicationCommandOptionType.Channel,
+      channel_types: [ChannelType.GuildText, ChannelType.GuildAnnouncement],
+      required: true,
+    },
+    {
+      name: "titel",
+      description: "De titel van de embed",
+      type: ApplicationCommandOptionType.String,
+      required: true,
+    },
+    {
+      name: "beschrijving",
+      description: "De beschrijving van de embed",
+      type: ApplicationCommandOptionType.String,
+      required: true,
+    },
+    {
+      name: "afbeelding",
+      description: "Optionele URL van de afbeelding in de embed",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    },
+    {
+      name: "ingeschakeld",
+      description: "Zet het dagelijkse ochtendbericht aan of uit",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    },
+  ],
+
+  callback: async (client: any, interaction: any) => {
+    if (!interaction.guildId) {
+      interaction.reply({
+        content: "Dit commando kan alleen in een server gebruikt worden.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const channel = interaction.options.getChannel("kanaal");
+    const title = interaction.options.getString("titel");
+    const description = interaction.options.getString("beschrijving");
+    const imageUrl = interaction.options.getString("afbeelding");
+    const enabled = interaction.options.getBoolean("ingeschakeld") ?? true;
+
+    if (imageUrl && !isValidImageUrl(imageUrl)) {
+      interaction.reply({
+        content: "Gebruik een geldige http(s)-URL voor de afbeelding.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const morningEmbedRepository = AppDataSource.getRepository(MorningEmbed);
+    let morningEmbed = await morningEmbedRepository.findOne({
+      where: { guildId: interaction.guildId },
+    });
+
+    if (!morningEmbed) {
+      morningEmbed = new MorningEmbed();
+      morningEmbed.guildId = interaction.guildId;
+      morningEmbed.lastSentDate = null;
+    }
+
+    morningEmbed.channelId = channel.id;
+    morningEmbed.title = title;
+    morningEmbed.description = description;
+    morningEmbed.imageUrl = imageUrl;
+    morningEmbed.enabled = enabled;
+
+    await morningEmbedRepository.save(morningEmbed);
+
+    const previewEmbed = new EmbedBuilder()
+      .setTitle(title)
+      .setDescription(description)
+      .setColor("#FF0000");
+
+    previewEmbed.addFields(
+      { name: "Quote", value: "De quote van de dag uit ZenQuotes komt hier." },
+      { name: "Author", value: "De auteur komt hier." }
+    );
+
+    if (imageUrl) {
+      previewEmbed.setImage(imageUrl);
+    }
+
+    interaction.reply({
+      content: `Het ochtendbericht is opgeslagen en staat ${
+        enabled ? "aan" : "uit"
+      }. Het wordt elke ochtend willekeurig tussen 7u en 9u verzonden in ${channel}.`,
+      embeds: [previewEmbed],
+      ephemeral: true,
+    });
+  },
+};

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,6 +1,6 @@
 import { DataSource } from "typeorm";
 import dotenv from "dotenv";
-import { User, Purchase, Subscription } from "./entity";
+import { User, Purchase, Subscription, MorningEmbed } from "./entity";
 
 dotenv.config();
 
@@ -13,7 +13,7 @@ export const AppDataSource = new DataSource({
   database: process.env.DATABASE_SCHEMA || "database", // Add fallback for database name
   synchronize: true,
   logging: false,
-  entities: [User, Purchase, Subscription],
+  entities: [User, Purchase, Subscription, MorningEmbed],
   migrations: ["./migration/*.ts"],
   subscribers: [],
 });

--- a/src/entity/MorningEmbed.ts
+++ b/src/entity/MorningEmbed.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity } from "typeorm";
+
+@Entity()
+export class MorningEmbed extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ unique: true })
+  guildId!: string;
+
+  @Column()
+  channelId!: string;
+
+  @Column()
+  title!: string;
+
+  @Column("text")
+  description!: string;
+
+  @Column({ nullable: true })
+  imageUrl!: string | null;
+
+  @Column({ default: true })
+  enabled!: boolean;
+
+  @Column({ nullable: true })
+  lastSentDate!: string | null;
+}

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -1,3 +1,4 @@
 export { Purchase } from "./Purchase";
 export { User } from "./User";
 export { Subscription } from "./Subscription";
+export { MorningEmbed } from "./MorningEmbed";

--- a/src/events/ready/0300morningEmbedScheduler.ts
+++ b/src/events/ready/0300morningEmbedScheduler.ts
@@ -1,0 +1,11 @@
+import { Client } from "discord.js";
+import { startMorningEmbedScheduler } from "../../services/morningEmbedScheduler";
+
+export default (client: Client & { morningEmbedSchedulerStarted?: boolean }) => {
+  if (client.morningEmbedSchedulerStarted) {
+    return;
+  }
+
+  client.morningEmbedSchedulerStarted = true;
+  startMorningEmbedScheduler(client);
+};

--- a/src/services/morningEmbedScheduler.ts
+++ b/src/services/morningEmbedScheduler.ts
@@ -1,0 +1,238 @@
+import { Client, EmbedBuilder, TextBasedChannel } from "discord.js";
+import { get } from "https";
+import { AppDataSource } from "../data-source";
+import { MorningEmbed } from "../entity";
+
+const MORNING_START_HOUR = 7;
+const MORNING_END_HOUR = 9;
+const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
+const DATABASE_WAIT_DELAY_MS = 1000;
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
+const DEFAULT_TIME_ZONE = "Europe/Brussels";
+const ZEN_QUOTES_TODAY_URL = "https://zenquotes.io/api/today";
+
+type ZenQuote = {
+  q: string;
+  a: string;
+};
+
+const getTimeZone = () =>
+  process.env.MORNING_EMBED_TIME_ZONE || DEFAULT_TIME_ZONE;
+
+const getTimeZoneParts = (date: Date, timeZone: string) => {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+
+  const parts = formatter.formatToParts(date).reduce((values, part) => {
+    if (part.type !== "literal") {
+      values[part.type] = Number(part.value);
+    }
+    return values;
+  }, {} as Record<string, number>);
+
+  if (parts.hour === 24) {
+    parts.hour = 0;
+  }
+
+  return parts;
+};
+
+const getTimeZoneOffset = (date: Date, timeZone: string) => {
+  const parts = getTimeZoneParts(date, timeZone);
+  const utcDate = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second
+  );
+
+  return utcDate - date.getTime();
+};
+
+const getDateInTimeZone = (
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  timeZone: string
+) => {
+  const utcGuess = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  const offset = getTimeZoneOffset(utcGuess, timeZone);
+  const date = new Date(utcGuess.getTime() - offset);
+  const correctedOffset = getTimeZoneOffset(date, timeZone);
+
+  if (correctedOffset !== offset) {
+    return new Date(utcGuess.getTime() - correctedOffset);
+  }
+
+  return date;
+};
+
+const getLocalDateKey = (date: Date, timeZone: string) => {
+  const parts = getTimeZoneParts(date, timeZone);
+  return `${parts.year}-${String(parts.month).padStart(2, "0")}-${String(
+    parts.day
+  ).padStart(2, "0")}`;
+};
+
+const getRandomMorningDate = (baseDate: Date, timeZone: string) => {
+  const parts = getTimeZoneParts(baseDate, timeZone);
+  const randomMinutes = Math.floor(
+    Math.random() * ((MORNING_END_HOUR - MORNING_START_HOUR) * 60 + 1)
+  );
+  const hour = MORNING_START_HOUR + Math.floor(randomMinutes / 60);
+  const minute = randomMinutes % 60;
+
+  return getDateInTimeZone(
+    parts.year,
+    parts.month,
+    parts.day,
+    hour,
+    minute,
+    0,
+    timeZone
+  );
+};
+
+const getTomorrow = (date: Date) => new Date(date.getTime() + ONE_DAY_IN_MS);
+
+const getNextRunDate = (timeZone: string) => {
+  const now = new Date();
+  let nextRun = getRandomMorningDate(now, timeZone);
+
+  if (nextRun <= now) {
+    nextRun = getRandomMorningDate(getTomorrow(now), timeZone);
+  }
+
+  return nextRun;
+};
+
+const waitForDatabase = async () => {
+  while (!AppDataSource.isInitialized) {
+    await new Promise((resolve) => setTimeout(resolve, DATABASE_WAIT_DELAY_MS));
+  }
+};
+
+const fetchDailyQuote = async (): Promise<ZenQuote | null> =>
+  new Promise((resolve) => {
+    get(ZEN_QUOTES_TODAY_URL, (response) => {
+      let body = "";
+
+      response.on("data", (chunk) => {
+        body += chunk;
+      });
+
+      response.on("end", () => {
+        try {
+          const quotes = JSON.parse(body);
+          const quote = Array.isArray(quotes) ? quotes[0] : null;
+
+          if (quote?.q && quote?.a) {
+            resolve({ q: quote.q, a: quote.a });
+            return;
+          }
+
+          console.log("ZenQuotes did not return a valid quote of the day.");
+          resolve(null);
+        } catch (error) {
+          console.log(`There was an error parsing the ZenQuotes response: ${error}`);
+          resolve(null);
+        }
+      });
+    }).on("error", (error) => {
+      console.log(`There was an error fetching the ZenQuotes daily quote: ${error}`);
+      resolve(null);
+    });
+  });
+
+const sendMorningEmbeds = async (client: Client, timeZone: string) => {
+  await waitForDatabase();
+
+  const today = getLocalDateKey(new Date(), timeZone);
+  const morningEmbedRepository = AppDataSource.getRepository(MorningEmbed);
+  const morningEmbeds = await morningEmbedRepository.find({
+    where: { enabled: true },
+  });
+  const dailyQuote = await fetchDailyQuote();
+
+  for (const morningEmbed of morningEmbeds) {
+    if (morningEmbed.lastSentDate === today) {
+      continue;
+    }
+
+    try {
+      const channel = await client.channels.fetch(morningEmbed.channelId);
+
+      if (!channel || !("send" in channel)) {
+        console.log(
+          `Morning embed channel ${morningEmbed.channelId} could not be found or is not sendable.`
+        );
+        continue;
+      }
+
+      const embed = new EmbedBuilder()
+        .setTitle(morningEmbed.title)
+        .setDescription(morningEmbed.description)
+        .setColor("#FF0000");
+
+      if (dailyQuote) {
+        embed.addFields(
+          { name: "Quote", value: dailyQuote.q },
+          { name: "Author", value: dailyQuote.a }
+        );
+      }
+
+      if (morningEmbed.imageUrl) {
+        embed.setImage(morningEmbed.imageUrl);
+      }
+
+      await (channel as TextBasedChannel).send({ embeds: [embed] });
+      morningEmbed.lastSentDate = today;
+      await morningEmbedRepository.save(morningEmbed);
+    } catch (error) {
+      console.log(
+        `There was an error sending morning embed ${morningEmbed.id}: ${error}`
+      );
+    }
+  }
+};
+
+const scheduleTimeout = (callback: () => void, delay: number) => {
+  if (delay > MAX_TIMEOUT_MS) {
+    setTimeout(() => scheduleTimeout(callback, delay - MAX_TIMEOUT_MS), MAX_TIMEOUT_MS);
+    return;
+  }
+
+  setTimeout(callback, delay);
+};
+
+export const startMorningEmbedScheduler = (client: Client) => {
+  const timeZone = getTimeZone();
+
+  const scheduleNextRun = () => {
+    const nextRun = getNextRunDate(timeZone);
+    const delay = nextRun.getTime() - Date.now();
+    console.log(
+      `Morning embed scheduler will run at ${nextRun.toISOString()} (${timeZone}).`
+    );
+
+    scheduleTimeout(async () => {
+      await sendMorningEmbeds(client, timeZone);
+      scheduleNextRun();
+    }, delay);
+  };
+
+  scheduleNextRun();
+};


### PR DESCRIPTION
### Motivation
- Provide servers a configurable daily morning embed message that posts once per day in a target channel.
- Allow server managers to set title, description, optional image, and enable/disable the message via a slash command.
- Ensure messages include a daily quote from ZenQuotes and respect a configurable time zone.

### Description
- Adds a new `MorningEmbed` entity to persist guild settings and `lastSentDate` and registers it in `AppDataSource` and `entity` index.
- Implements `/ochtendbericht` slash command to configure the morning embed (channel, title, description, optional image URL, enabled flag) with basic image URL validation and preview embed.
- Adds a scheduler service `startMorningEmbedScheduler` that picks a random time between 07:00 and 09:00 (default `Europe/Brussels` or `MORNING_EMBED_TIME_ZONE`) to send enabled embeds, fetches the ZenQuotes quote of the day, and updates `lastSentDate` to avoid duplicate sends.
- Wires the scheduler to run once on bot ready via a new ready event and documents usage in `README.md`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1b79694a40832cb55c7e7845e14662)